### PR TITLE
Fix tag being set to chasing state while it

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "astro-icon": "^1.1.0",
     "astro-seo": "^0.8.4",
     "date-fns": "^3.6.0",
+    "lodash": "^4.17.21",
     "motion": "^10.18.0",
     "powerglitch": "^2.3.3",
     "react": "18.2.0",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@iconify-json/el": "^1.1.8",
     "@tailwindcss/typography": "^0.5.13",
+    "@types/lodash": "^4.17.13",
     "daisyui": "^4.12.2",
     "vite": "^6.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       motion:
         specifier: ^10.18.0
         version: 10.18.0
@@ -75,6 +78,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.13
         version: 0.5.15(tailwindcss@3.4.16)
+      '@types/lodash':
+        specifier: ^4.17.13
+        version: 4.17.13
       daisyui:
         specifier: ^4.12.2
         version: 4.12.14(postcss@8.4.31)
@@ -907,6 +913,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/lodash@4.17.13':
+    resolution: {integrity: sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -3696,6 +3705,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/lodash@4.17.13': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -104,6 +104,12 @@ export default function Tag({
     };
   }, [isChasing, mousePosition, speed, catchDistance, isCaught]);
 
+  const debouncedSetIsChasing = useDebounce(
+    () => setIsChasing(true),
+    1000,
+    { leading: false },
+  );
+
   // Start chasing after hover
   const handleMouseLeave = () => {
     console.log('Mouse entered');
@@ -112,7 +118,7 @@ export default function Tag({
       if (rect) {
         setTextPosition({ x: rect.left, y: rect.top });
       }
-      setTimeout(() => setIsChasing(true), 1000);
+      debouncedSetIsChasing();
     }
   };
 
@@ -150,6 +156,7 @@ export default function Tag({
 
       }}
       onMouseLeave={handleMouseLeave}
+      onMouseEnter={() => debouncedSetIsChasing.cancel()}
     >
       {text}
     </span>

--- a/src/utils/useDebounce.ts
+++ b/src/utils/useDebounce.ts
@@ -1,0 +1,25 @@
+import { useEffect, useMemo, useRef } from "react";
+import debounce from "lodash/debounce";
+
+// https://www.developerway.com/posts/debouncing-in-react?ht-comment-id=13350358
+export function useDebounce<T extends unknown[], S>(
+  callback: (...args: T) => S,
+  delay: number = 1000,
+  debounceOptions?: Parameters<typeof debounce>[2],
+) {
+  const ref = useRef(callback);
+
+  useEffect(() => {
+    ref.current = callback;
+  }, [callback]);
+
+  const debouncedCallback = useMemo(() => {
+    const func = (...arg: T) => {
+      return ref.current(...arg);
+    };
+
+    return debounce(func, delay, debounceOptions);
+  }, [delay]);
+
+  return debouncedCallback;
+}


### PR DESCRIPTION
It's currently possible to get into a state where there's a "TAG" chasing you while you're "IT!".  To reproduce, enter and leave the "TAG" with your mouse ~3 times in quick succession, while letting the "TAG" catch your mouse immediately after leaving the last time.

My current belief about why this was happening was that `handleMouseLeave` called `setTimeout(() => setIsChasing(true));`, while `animate` calls `setIsChasing(false);`.  If you trigged a mouseleave event, waited a bit, then triggered a second one, and then got "caught" and turned into "IT!" before the second `setTimeout` resolved, the second `setTimeout` resolving would then set `isChasing` back to true after it got set to `false` by `animate`.

The reason the solution involves a custom hook is because (from prior experience) raw debouncing in React is cursed for referential stability reasons.  I'm not sure the implementation is ideal but it does seem to fix the problem, though I only tested it briefly.